### PR TITLE
Round float to 2 decimal places without scientific notation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/floscodes/golang-thousands
+module github.com/xviaver/golang-thousands
 
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/xviaver/golang-thousands
+module github.com/floscodes/golang-thousands
 
 go 1.16

--- a/thousands.go
+++ b/thousands.go
@@ -21,7 +21,7 @@ func Separate(N interface{}, lang ...string) (string, error) {
 
 	}
 
-	n := fmt.Sprintf("%v", N)
+	n := fmt.Sprintf("%.2f", N)
 
 	if len(lang) < 1 {
 		lang[0] = "en"


### PR DESCRIPTION
Hi, I have been using this package for my projects.  I just faced it shows the result with a scientific notation (E) when the numbers get higher